### PR TITLE
Updating README and Update Reporting (IN NOT RECEIVED)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "InComm-V2",
+  "name": "Pulse",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
@@ -228,7 +228,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -579,7 +578,6 @@
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -2310,8 +2308,7 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -2580,7 +2577,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",

--- a/src/public/appReports.js
+++ b/src/public/appReports.js
@@ -309,10 +309,10 @@ async function fetchInNotReceivedByFirstStatus({ searchValue = '', typeValue = '
 
         items.sort((/** @type {DemoItem} */ a, /** @type {DemoItem} */ b) => itemDateMs(a) - itemDateMs(b));
 
-        const firstStatus = normalizedStatus(items[0]);
+        const firstStatusKey = normalizedStatusKey(items[0]);
         const latestItem = items[items.length - 1];
 
-        if (firstStatus !== 'Inbound Received' && latestItem) {
+        if (firstStatusKey !== 'inbound received' && latestItem) {
             inNotReceivedItems.push(latestItem);
         }
     }


### PR DESCRIPTION
This pull request makes a small but important change to the logic that determines whether to include an item based on its status. Specifically, it updates the code to use normalized status keys (lowercase and standardized) instead of display names when checking for the 'inbound received' status.

- Updated the status comparison in `fetchInNotReceivedByFirstStatus` to use `normalizedStatusKey` and compare against the standardized key `'inbound received'`, improving consistency and reducing potential errors from display name mismatches.